### PR TITLE
Refactor PufferProtocol to keep <24KB

### DIFF
--- a/mainnet-contracts/script/DeployPuffer.s.sol
+++ b/mainnet-contracts/script/DeployPuffer.s.sol
@@ -185,7 +185,10 @@ contract DeployPuffer is BaseScript {
         PufferProtocolLogic pufferProtocolLogic = new PufferProtocolLogic();
 
         // Initialize the Pool
-        pufferProtocol.initialize({ accessManager: address(accessManager), pufferProtocolLogic: address(pufferProtocolLogic) });
+        pufferProtocol.initialize({
+            accessManager: address(accessManager),
+            pufferProtocolLogic: address(pufferProtocolLogic)
+        });
 
         vm.label(address(accessManager), "AccessManager");
         vm.label(address(operationsCoordinator), "OperationsCoordinator");

--- a/mainnet-contracts/script/DeployPuffer.s.sol
+++ b/mainnet-contracts/script/DeployPuffer.s.sol
@@ -182,7 +182,15 @@ contract DeployPuffer is BaseScript {
             address(moduleManager), abi.encodeCall(moduleManager.initialize, (address(accessManager)))
         );
 
-        PufferProtocolLogic pufferProtocolLogic = new PufferProtocolLogic();
+        PufferProtocolLogic pufferProtocolLogic = new PufferProtocolLogic({
+            pufferVault: PufferVaultV5(payable(pufferVault)),
+            validatorTicket: ValidatorTicket(address(validatorTicketProxy)),
+            guardianModule: GuardianModule(payable(guardiansDeployment.guardianModule)),
+            moduleManager: address(moduleManagerProxy),
+            oracle: IPufferOracleV2(oracle),
+            beaconDepositContract: getStakingContract(),
+            pufferRevenueDistributor: payable(revenueDepositor)
+        });
 
         // Initialize the Pool
         pufferProtocol.initialize({

--- a/mainnet-contracts/script/DeployPuffer.s.sol
+++ b/mainnet-contracts/script/DeployPuffer.s.sol
@@ -30,6 +30,7 @@ import { RewardsCoordinatorMock } from "../test/mocks/RewardsCoordinatorMock.sol
 import { EigenAllocationManagerMock } from "../test/mocks/EigenAllocationManagerMock.sol";
 import { RestakingOperatorController } from "../src/RestakingOperatorController.sol";
 import { RestakingOperatorController } from "../src/RestakingOperatorController.sol";
+import { PufferProtocolLogic } from "../src/PufferProtocolLogic.sol";
 /**
  * @title DeployPuffer
  * @author Puffer Finance
@@ -181,8 +182,10 @@ contract DeployPuffer is BaseScript {
             address(moduleManager), abi.encodeCall(moduleManager.initialize, (address(accessManager)))
         );
 
+        PufferProtocolLogic pufferProtocolLogic = new PufferProtocolLogic();
+
         // Initialize the Pool
-        pufferProtocol.initialize({ accessManager: address(accessManager) });
+        pufferProtocol.initialize({ accessManager: address(accessManager), pufferProtocolLogic: address(pufferProtocolLogic) });
 
         vm.label(address(accessManager), "AccessManager");
         vm.label(address(operationsCoordinator), "OperationsCoordinator");

--- a/mainnet-contracts/src/GuardianModule.sol
+++ b/mainnet-contracts/src/GuardianModule.sol
@@ -217,12 +217,22 @@ contract GuardianModule is AccessManaged, IGuardianModule {
     /**
      * @inheritdoc IGuardianModule
      */
-    function validateWithdrawalRequest(bytes[] calldata eoaSignatures, bytes32 messageHash) external view {
+    function validateWithdrawalRequest(
+        address node,
+        bytes memory pubKey,
+        uint256 gweiAmount,
+        uint256 nonce,
+        uint256 deadline,
+        bytes[] calldata guardianEOASignatures
+    ) external view {
         // Recreate the message hash
-        bytes32 signedMessageHash = LibGuardianMessages._getAnyHashedMessage(messageHash);
+        bytes32 signedMessageHash =
+            LibGuardianMessages._getWithdrawalRequestMessage(node, pubKey, gweiAmount, nonce, deadline);
 
-        bool validSignatures =
-            validateGuardiansEOASignatures({ eoaSignatures: eoaSignatures, signedMessageHash: signedMessageHash });
+        bool validSignatures = validateGuardiansEOASignatures({
+            eoaSignatures: guardianEOASignatures,
+            signedMessageHash: signedMessageHash
+        });
 
         if (!validSignatures) {
             revert Unauthorized();
@@ -232,12 +242,21 @@ contract GuardianModule is AccessManaged, IGuardianModule {
     /**
      * @inheritdoc IGuardianModule
      */
-    function validateTotalEpochsValidated(bytes[] calldata eoaSignatures, bytes32 messageHash) external view {
+    function validateTotalEpochsValidated(
+        address node,
+        uint256 totalEpochsValidated,
+        uint256 nonce,
+        uint256 deadline,
+        bytes[] calldata guardianEOASignatures
+    ) external view {
         // Recreate the message hash
-        bytes32 signedMessageHash = LibGuardianMessages._getAnyHashedMessage(messageHash);
+        bytes32 signedMessageHash =
+            LibGuardianMessages._getTotalEpochsValidatedMessage(node, totalEpochsValidated, nonce, deadline);
 
-        bool validSignatures =
-            validateGuardiansEOASignatures({ eoaSignatures: eoaSignatures, signedMessageHash: signedMessageHash });
+        bool validSignatures = validateGuardiansEOASignatures({
+            eoaSignatures: guardianEOASignatures,
+            signedMessageHash: signedMessageHash
+        });
 
         if (!validSignatures) {
             revert Unauthorized();

--- a/mainnet-contracts/src/LibGuardianMessages.sol
+++ b/mainnet-contracts/src/LibGuardianMessages.sol
@@ -88,12 +88,39 @@ library LibGuardianMessages {
     }
 
     /**
-     * @notice Returns the message to be signed for any message
-     * @param hashedMessage is the hashed message to be signed
+     * @notice Returns the message to be signed for the total epochs validated
+     * @param node is the node operator address
+     * @param totalEpochsValidated is the total epochs validated
+     * @param nonce is the nonce for the node and the function selector
+     * @param deadline is the deadline of the signature
      * @return the message to be signed
      */
-    function _getAnyHashedMessage(bytes32 hashedMessage) internal pure returns (bytes32) {
-        return hashedMessage.toEthSignedMessageHash();
+    function _getTotalEpochsValidatedMessage(
+        address node,
+        uint256 totalEpochsValidated,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(node, totalEpochsValidated, nonce, deadline)).toEthSignedMessageHash();
+    }
+
+    /**
+     * @notice Returns the message to be signed for the withdrawal request
+     * @param node is the node operator address
+     * @param pubKey is the public key
+     * @param gweiAmount is the amount in gwei
+     * @param nonce is the nonce for the node and the function selector
+     * @param deadline is the deadline of the signature
+     * @return the message to be signed
+     */
+    function _getWithdrawalRequestMessage(
+        address node,
+        bytes memory pubKey,
+        uint256 gweiAmount,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(node, pubKey, gweiAmount, nonce, deadline)).toEthSignedMessageHash();
     }
 }
 /* solhint-disable func-named-parameters */

--- a/mainnet-contracts/src/ProtocolConstants.sol
+++ b/mainnet-contracts/src/ProtocolConstants.sol
@@ -5,7 +5,7 @@ import { IPufferProtocol } from "./interface/IPufferProtocol.sol";
 import { Status } from "./struct/Status.sol";
 
 abstract contract ProtocolConstants {
-        /**
+    /**
      * @notice Thrown when the deposit state that is provided doesn't match the one on Beacon deposit contract
      */
     error InvalidDepositRootHash();

--- a/mainnet-contracts/src/ProtocolConstants.sol
+++ b/mainnet-contracts/src/ProtocolConstants.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IPufferProtocol } from "./interface/IPufferProtocol.sol";
+import { Status } from "./struct/Status.sol";
+
+abstract contract ProtocolConstants {
+        /**
+     * @notice Thrown when the deposit state that is provided doesn't match the one on Beacon deposit contract
+     */
+    error InvalidDepositRootHash();
+
+    /**
+     * @notice Thrown when the node operator tries to withdraw VTs from the PufferProtocol but has active/pending validators
+     * @dev Signature "0x22242546"
+     */
+    error ActiveOrPendingValidatorsExist();
+
+    /**
+     * @notice Thrown on the module creation if the module already exists
+     * @dev Signature "0x2157f2d7"
+     */
+    error ModuleAlreadyExists();
+
+    /**
+     * @notice Thrown when the new validators tires to register to a module, but the validator limit for that module is already reached
+     * @dev Signature "0xb75c5781"
+     */
+    error ValidatorLimitForModuleReached();
+
+    /**
+     * @notice Thrown when the BLS public key is not valid
+     * @dev Signature "0x7eef7967"
+     */
+    error InvalidBLSPubKey();
+
+    /**
+     * @notice Thrown when validator is not in a valid state
+     * @dev Signature "0x3001591c"
+     */
+    error InvalidValidatorState(Status status);
+
+    /**
+     * @notice Thrown if the sender did not send enough ETH in the transaction
+     * @dev Signature "0x242b035c"
+     */
+    error InvalidETHAmount();
+
+    /**
+     * @notice Thrown if the sender tries to register validator with invalid VT amount
+     * @dev Signature "0x95c01f62"
+     */
+    error InvalidVTAmount();
+
+    /**
+     * @notice Thrown if the ETH transfer from the PufferModule to the PufferVault fails
+     * @dev Signature "0x625a40e6"
+     */
+    error Failed();
+
+    /**
+     * @notice Thrown if the validator is not valid
+     * @dev Signature "0x682a6e7c"
+     */
+    error InvalidValidator();
+
+    /**
+     * @notice Thrown if the input array length mismatch
+     * @dev Signature "0x43714afd"
+     */
+    error InputArrayLengthMismatch();
+
+    /**
+     * @notice Thrown if the input array length is zero
+     * @dev Signature "0x796cc525"
+     */
+    error InputArrayLengthZero();
+
+    /**
+     * @notice Thrown if the number of batches is 0 or greater than 64
+     * @dev Signature "0x4ea54df9"
+     */
+    error InvalidNumberOfBatches();
+
+    /**
+     * @notice Thrown if the withdrawal amount is invalid
+     * @dev Signature "0xdb73cdf0"
+     */
+    error InvalidWithdrawAmount();
+
+    /**
+     * @notice Thrown when the total epochs validated is invalid
+     * @dev Signature "0x1af51909"
+     */
+    error InvalidTotalEpochsValidated();
+
+    /**
+     * @notice Thrown when the deadline is exceeded
+     * @dev Signature "0xddff8620"
+     */
+    error DeadlineExceeded();
+
+    /**
+     * @dev BLS public keys are 48 bytes long
+     */
+    uint256 internal constant _BLS_PUB_KEY_LENGTH = 48;
+
+    /**
+     * @dev ETH Amount required to be deposited as a bond
+     */
+    uint256 internal constant _VALIDATOR_BOND = 1.5 ether;
+
+    /**
+     * @dev Minimum validation time in epochs (per batch number)
+     * Roughly: 30 days * 225 epochs per day = 6750 epochs
+     */
+    uint256 internal constant _MINIMUM_EPOCHS_VALIDATION_REGISTRATION = 6750;
+
+    /**
+     * @dev Minimum validation time in epochs (per batch number)
+     * Roughly: 5 days * 225 epochs per day = 1125 epochs
+     */
+    uint256 internal constant _MINIMUM_EPOCHS_VALIDATION_DEPOSIT = 1125;
+
+    /**
+     * @dev Maximum validation time in epochs (per batch number)
+     * Roughly: 180 days * 225 epochs per day = 40500 epochs
+     */
+    uint256 internal constant _MAXIMUM_EPOCHS_VALIDATION_DEPOSIT = 40500;
+
+    /**
+     * @dev Number of epochs per day
+     */
+    uint256 internal constant _EPOCHS_PER_DAY = 225;
+
+    /**
+     * @dev Default "PUFFER_MODULE_0" module
+     */
+    bytes32 internal constant _PUFFER_MODULE_0 = bytes32("PUFFER_MODULE_0");
+
+    /**
+     * @dev 32 ETH in Gwei
+     */
+    uint256 internal constant _32_ETH_GWEI = 32 * 10 ** 9;
+
+    bytes32 internal constant _FUNCTION_SELECTOR_REGISTER_VALIDATOR_KEY = IPufferProtocol.registerValidatorKey.selector;
+    bytes32 internal constant _FUNCTION_SELECTOR_DEPOSIT_VALIDATION_TIME =
+        IPufferProtocol.depositValidationTime.selector;
+    bytes32 internal constant _FUNCTION_SELECTOR_REQUEST_WITHDRAWAL = IPufferProtocol.requestWithdrawal.selector;
+    bytes32 internal constant _FUNCTION_SELECTOR_BATCH_HANDLE_WITHDRAWALS =
+        IPufferProtocol.batchHandleWithdrawals.selector;
+}

--- a/mainnet-contracts/src/ProtocolConstants.sol
+++ b/mainnet-contracts/src/ProtocolConstants.sol
@@ -3,6 +3,12 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import { IPufferProtocol } from "./interface/IPufferProtocol.sol";
 import { Status } from "./struct/Status.sol";
+import { PufferModuleManager } from "./PufferModuleManager.sol";
+import { IPufferOracleV2 } from "./interface/IPufferOracleV2.sol";
+import { IGuardianModule } from "./interface/IGuardianModule.sol";
+import { IBeaconDepositContract } from "./interface/IBeaconDepositContract.sol";
+import { ValidatorTicket } from "./ValidatorTicket.sol";
+import { PufferVaultV5 } from "./PufferVaultV5.sol";
 
 abstract contract ProtocolConstants {
     /**
@@ -149,4 +155,36 @@ abstract contract ProtocolConstants {
     bytes32 internal constant _FUNCTION_SELECTOR_REQUEST_WITHDRAWAL = IPufferProtocol.requestWithdrawal.selector;
     bytes32 internal constant _FUNCTION_SELECTOR_BATCH_HANDLE_WITHDRAWALS =
         IPufferProtocol.batchHandleWithdrawals.selector;
+
+    IGuardianModule internal immutable _GUARDIAN_MODULE;
+
+    ValidatorTicket internal immutable _VALIDATOR_TICKET;
+
+    PufferVaultV5 internal immutable _PUFFER_VAULT;
+
+    PufferModuleManager internal immutable _PUFFER_MODULE_MANAGER;
+
+    IPufferOracleV2 internal immutable _PUFFER_ORACLE;
+
+    IBeaconDepositContract internal immutable _BEACON_DEPOSIT_CONTRACT;
+
+    address payable internal immutable _PUFFER_REVENUE_DISTRIBUTOR;
+
+    constructor(
+        PufferVaultV5 pufferVault,
+        IGuardianModule guardianModule,
+        address moduleManager,
+        ValidatorTicket validatorTicket,
+        IPufferOracleV2 oracle,
+        address beaconDepositContract,
+        address payable pufferRevenueDistributor
+    ) {
+        _GUARDIAN_MODULE = guardianModule;
+        _PUFFER_VAULT = PufferVaultV5(payable(address(pufferVault)));
+        _PUFFER_MODULE_MANAGER = PufferModuleManager(payable(moduleManager));
+        _VALIDATOR_TICKET = validatorTicket;
+        _PUFFER_ORACLE = oracle;
+        _BEACON_DEPOSIT_CONTRACT = IBeaconDepositContract(beaconDepositContract);
+        _PUFFER_REVENUE_DISTRIBUTOR = pufferRevenueDistributor;
+    }
 }

--- a/mainnet-contracts/src/ProtocolSignatureNonces.sol
+++ b/mainnet-contracts/src/ProtocolSignatureNonces.sol
@@ -78,23 +78,4 @@ abstract contract ProtocolSignatureNonces {
             return $._nonces[selector][owner]++;
         }
     }
-
-    /**
-     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.
-     * @param selector The function selector that determines the nonce space
-     * @param owner The address whose nonce to validate and consume
-     * @param nonce The expected nonce value
-     *
-     * @dev This function validates that the provided nonce matches the expected
-     * current nonce before consuming it. This prevents replay attacks and
-     * ensures proper signature ordering.
-     *
-     * @dev Reverts with InvalidAccountNonce if the nonce doesn't match.
-     */
-    function _useCheckedNonce(bytes32 selector, address owner, uint256 nonce) internal virtual {
-        uint256 current = _useNonce(selector, owner);
-        if (nonce != current) {
-            revert InvalidAccountNonce(selector, owner, current);
-        }
-    }
 }

--- a/mainnet-contracts/src/PufferProtocolBase.sol
+++ b/mainnet-contracts/src/PufferProtocolBase.sol
@@ -9,8 +9,10 @@ import { IGuardianModule } from "./interface/IGuardianModule.sol";
 import { IBeaconDepositContract } from "./interface/IBeaconDepositContract.sol";
 import { ValidatorTicket } from "./ValidatorTicket.sol";
 import { PufferVaultV5 } from "./PufferVaultV5.sol";
+import { ProtocolSignatureNonces } from "./ProtocolSignatureNonces.sol";
+import { PufferProtocolStorage } from "./PufferProtocolStorage.sol";
 
-abstract contract ProtocolConstants {
+abstract contract PufferProtocolBase is PufferProtocolStorage, ProtocolSignatureNonces {
     /**
      * @notice Thrown when the deposit state that is provided doesn't match the one on Beacon deposit contract
      */

--- a/mainnet-contracts/src/PufferProtocolLogic.sol
+++ b/mainnet-contracts/src/PufferProtocolLogic.sol
@@ -18,8 +18,6 @@ import { ValidatorTicket } from "./ValidatorTicket.sol";
 import { PufferVaultV5 } from "./PufferVaultV5.sol";
 import { EpochsValidatedSignature } from "./struct/Signatures.sol";
 
-import "forge-std/console.sol";
-
 contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, ProtocolConstants {
     constructor(
         PufferVaultV5 pufferVault,
@@ -97,6 +95,7 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
      */
     function _useVTOrValidationTime(EpochsValidatedSignature memory epochsValidatedSignature)
         external
+        payable
         returns (uint256 vtAmountToBurn)
     {
         ProtocolStorage storage $ = _getPufferProtocolStorage();
@@ -154,9 +153,8 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
      */
     function _settleVTAccounting(EpochsValidatedSignature memory epochsValidatedSignature, uint256 deprecated_burntVTs)
         public
+        payable
     {
-        console.log("settleVTAccounting");
-
         ProtocolStorage storage $ = _getPufferProtocolStorage();
         address node = epochsValidatedSignature.nodeOperator;
         // There is nothing to settle if this is the first validator for the node operator

--- a/mainnet-contracts/src/PufferProtocolLogic.sol
+++ b/mainnet-contracts/src/PufferProtocolLogic.sol
@@ -9,12 +9,7 @@ import { Status } from "./struct/Validator.sol";
 import { ProtocolConstants } from "./ProtocolConstants.sol";
 import { IPufferProtocol } from "./interface/IPufferProtocol.sol";
 
-contract PufferProtocolLogic is
-    PufferProtocolStorage,
-    ProtocolSignatureNonces,
-    ProtocolConstants
-{
-
+contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, ProtocolConstants {
     /**
      * @dev This function should only be called by the PufferProtocol contract through a delegatecall
      */

--- a/mainnet-contracts/src/PufferProtocolLogic.sol
+++ b/mainnet-contracts/src/PufferProtocolLogic.sol
@@ -3,22 +3,47 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import { PufferProtocolStorage } from "./PufferProtocolStorage.sol";
 import { ProtocolStorage } from "./struct/ProtocolStorage.sol";
-import { ProtocolSignatureNonces } from "./ProtocolSignatureNonces.sol";
 import { Validator } from "./struct/Validator.sol";
 import { Status } from "./struct/Validator.sol";
-import { ProtocolConstants } from "./ProtocolConstants.sol";
+import { StoppedValidatorInfo } from "./struct/StoppedValidatorInfo.sol";
+import { ValidatorKeyData } from "./struct/ValidatorKeyData.sol";
+import { PufferProtocolBase } from "./PufferProtocolBase.sol";
 import { IPufferProtocol } from "./interface/IPufferProtocol.sol";
+import { IPufferProtocolLogic } from "./interface/IPufferProtocolLogic.sol";
 import { PufferModuleManager } from "./PufferModuleManager.sol";
+import { PufferModule } from "./PufferModule.sol";
 import { IPufferOracleV2 } from "./interface/IPufferOracleV2.sol";
 import { IGuardianModule } from "./interface/IGuardianModule.sol";
 import { IBeaconDepositContract } from "./interface/IBeaconDepositContract.sol";
 import { ValidatorTicket } from "./ValidatorTicket.sol";
 import { PufferVaultV5 } from "./PufferVaultV5.sol";
 import { EpochsValidatedSignature } from "./struct/Signatures.sol";
+import { InvalidAddress } from "./Errors.sol";
 
-contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, ProtocolConstants {
+contract PufferProtocolLogic is
+    PufferProtocolBase,
+    IPufferProtocolLogic
+{
+    /**
+     * @dev Helper struct for the full withdrawals accounting
+     * The amounts of VT and pufETH to burn at the end of the withdrawal
+     */
+    struct BurnAmounts {
+        uint256 vt;
+        uint256 pufETH;
+    }
+
+    /**
+     * @dev Helper struct for the full withdrawals accounting
+     * The amounts of pufETH to send to the node operator
+     */
+    struct Withdrawals {
+        uint256 pufETHAmount;
+        address node;
+        uint256 numBatches;
+    }
+
     constructor(
         PufferVaultV5 pufferVault,
         IGuardianModule guardianModule,
@@ -28,7 +53,7 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
         address beaconDepositContract,
         address payable pufferRevenueDistributor
     )
-        ProtocolConstants(
+        PufferProtocolBase(
             pufferVault,
             guardianModule,
             moduleManager,
@@ -40,11 +65,159 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
     { }
 
     /**
+     * @notice Check IPufferProtocol.depositValidationTime
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _depositValidationTime(EpochsValidatedSignature memory epochsValidatedSignature)
+        external
+        payable
+        override
+    {
+        if (block.timestamp > epochsValidatedSignature.deadline) {
+            revert DeadlineExceeded();
+        }
+
+        require(epochsValidatedSignature.nodeOperator != address(0), InvalidAddress());
+        ProtocolStorage storage $ = _getPufferProtocolStorage();
+        uint256 epochCurrentPrice = _PUFFER_ORACLE.getValidatorTicketPrice();
+        uint8 operatorNumBatches = $.nodeOperatorInfo[epochsValidatedSignature.nodeOperator].numBatches;
+        require(
+            msg.value >= operatorNumBatches * _MINIMUM_EPOCHS_VALIDATION_DEPOSIT * epochCurrentPrice
+                && msg.value <= operatorNumBatches * _MAXIMUM_EPOCHS_VALIDATION_DEPOSIT * epochCurrentPrice,
+            InvalidETHAmount()
+        );
+
+        epochsValidatedSignature.functionSelector = _FUNCTION_SELECTOR_DEPOSIT_VALIDATION_TIME;
+
+        uint256 burnAmount = _useVTOrValidationTime($, epochsValidatedSignature);
+
+        if (burnAmount > 0) {
+            _VALIDATOR_TICKET.burn(burnAmount);
+        }
+
+        $.nodeOperatorInfo[epochsValidatedSignature.nodeOperator].validationTime += SafeCast.toUint96(msg.value);
+        emit IPufferProtocol.ValidationTimeDeposited({
+            node: epochsValidatedSignature.nodeOperator,
+            ethAmount: msg.value
+        });
+    }
+
+    /**
+     * @notice Check IPufferProtocol.withdrawValidationTime
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _withdrawValidationTime(uint96 amount, address recipient) external override {
+        ProtocolStorage storage $ = _getPufferProtocolStorage();
+
+        // Node operator can only withdraw if they have no active or pending validators
+        // In the future, we plan to allow node operators to withdraw VTs even if they have active/pending validators.
+        if (
+            $.nodeOperatorInfo[msg.sender].activeValidatorCount + $.nodeOperatorInfo[msg.sender].pendingValidatorCount
+                != 0
+        ) {
+            revert ActiveOrPendingValidatorsExist();
+        }
+
+        // Reverts if insufficient balance
+        // nosemgrep basic-arithmetic-underflow
+        $.nodeOperatorInfo[msg.sender].validationTime -= amount;
+
+        // WETH is a contract that has a fallback function that accepts ETH, and never reverts
+        address weth = _PUFFER_VAULT.asset();
+        weth.call{ value: amount }("");
+        // Transfer WETH to the recipient
+        ERC20(weth).transfer(recipient, amount);
+
+        emit IPufferProtocol.ValidationTimeWithdrawn(msg.sender, recipient, amount);
+    }
+
+    /**
+     * @notice Check IPufferProtocol.registerValidatorKey
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _registerValidatorKey(
+        ValidatorKeyData calldata data,
+        bytes32 moduleName,
+        uint256 totalEpochsValidated,
+        bytes[] calldata vtConsumptionSignature,
+        uint256 deadline
+    ) external payable override {
+        if (block.timestamp > deadline) {
+            revert DeadlineExceeded();
+        }
+
+        ProtocolStorage storage $ = _getPufferProtocolStorage();
+
+        _checkValidatorRegistrationInputs({ $: $, data: data, moduleName: moduleName });
+
+        uint256 epochCurrentPrice = _PUFFER_ORACLE.getValidatorTicketPrice();
+        uint8 numBatches = data.numBatches;
+        uint256 bondAmountEth = _VALIDATOR_BOND * numBatches;
+
+        // The node operator must deposit 1.5 ETH (per batch) or more + minimum validation time for ~30 days
+        // At the moment that's roughly 30 days * 225 (there is roughly 225 epochs per day)
+        uint256 minimumETHRequired =
+            bondAmountEth + (numBatches * _MINIMUM_EPOCHS_VALIDATION_REGISTRATION * epochCurrentPrice);
+
+        require(msg.value >= minimumETHRequired, InvalidETHAmount());
+
+        emit IPufferProtocol.ValidationTimeDeposited({ node: msg.sender, ethAmount: (msg.value - bondAmountEth) });
+
+        _settleVTAccounting({
+            $: $,
+            epochsValidatedSignature: EpochsValidatedSignature({
+                nodeOperator: msg.sender,
+                totalEpochsValidated: totalEpochsValidated,
+                functionSelector: _FUNCTION_SELECTOR_REGISTER_VALIDATOR_KEY,
+                deadline: deadline,
+                signatures: vtConsumptionSignature
+            }),
+            deprecated_burntVTs: 0
+        });
+
+        // The bond is converted to pufETH at the current exchange rate
+        uint256 pufETHBondAmount = _PUFFER_VAULT.depositETH{ value: bondAmountEth }(address(this));
+
+        uint256 pufferModuleIndex = $.pendingValidatorIndices[moduleName];
+
+        // No need for SafeCast
+        $.validators[moduleName][pufferModuleIndex] = Validator({
+            pubKey: data.blsPubKey,
+            status: Status.PENDING,
+            module: address($.modules[moduleName]),
+            bond: uint96(pufETHBondAmount),
+            node: msg.sender,
+            numBatches: numBatches
+        });
+
+        // Increment indices for this module and number of validators registered
+        unchecked {
+            $.nodeOperatorInfo[msg.sender].epochPrice = epochCurrentPrice;
+            $.nodeOperatorInfo[msg.sender].validationTime += (msg.value - bondAmountEth);
+            ++$.nodeOperatorInfo[msg.sender].pendingValidatorCount;
+            ++$.pendingValidatorIndices[moduleName];
+            ++$.moduleLimits[moduleName].numberOfRegisteredValidators;
+        }
+
+        emit IPufferProtocol.NumberOfRegisteredValidatorsChanged({
+            moduleName: moduleName,
+            newNumberOfRegisteredValidators: $.moduleLimits[moduleName].numberOfRegisteredValidators
+        });
+        emit IPufferProtocol.ValidatorKeyRegistered({
+            pubKey: data.blsPubKey,
+            pufferModuleIndex: pufferModuleIndex,
+            moduleName: moduleName,
+            numBatches: numBatches
+        });
+    }
+
+    /**
      * @dev This function should only be called by the PufferProtocol contract through a delegatecall
      */
     function _requestConsolidation(bytes32 moduleName, uint256[] calldata srcIndices, uint256[] calldata targetIndices)
         external
         payable
+        override
     {
         if (srcIndices.length == 0) {
             revert InputArrayLengthZero();
@@ -82,63 +255,127 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
     }
 
     /**
-     * @dev Internal function to return the deprecated validator tickets burn amount
-     *      and/or consume the validation time from the node operator
-     * @dev The deprecated vt balance is reduced here but the actual VT is not burned here (for efficiency)
-     * @param epochsValidatedSignature is a struct that contains:
-     * - functionSelector: Identifier of the function that initiated this flow
-     * - totalEpochsValidated: The total number of epochs validated by that node operator
-     * - nodeOperator: The node operator address
-     * - deadline: The deadline for the signature
-     * - signatures: The signatures of the guardians over the total number of epochs validated
-     * @return vtAmountToBurn The amount of VT to burn
+     * @notice Check IPufferProtocol.skipProvisioning
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
      */
-    function _useVTOrValidationTime(EpochsValidatedSignature memory epochsValidatedSignature)
-        external
-        payable
-        returns (uint256 vtAmountToBurn)
-    {
+    function _skipProvisioning(bytes32 moduleName, bytes[] calldata guardianEOASignatures) external override {
         ProtocolStorage storage $ = _getPufferProtocolStorage();
-        address nodeOperator = epochsValidatedSignature.nodeOperator;
-        uint256 previousTotalEpochsValidated = $.nodeOperatorInfo[nodeOperator].totalEpochsValidated;
 
-        if (previousTotalEpochsValidated == epochsValidatedSignature.totalEpochsValidated) {
-            return 0;
+        uint256 skippedIndex = $.nextToBeProvisioned[moduleName];
+
+        address node = $.validators[moduleName][skippedIndex].node;
+
+        // Check the signatures (reverts if invalid)
+        _GUARDIAN_MODULE.validateSkipProvisioning({
+            moduleName: moduleName,
+            skippedIndex: skippedIndex,
+            guardianEOASignatures: guardianEOASignatures
+        });
+
+        uint256 vtPricePerEpoch = _PUFFER_ORACLE.getValidatorTicketPrice();
+
+        $.nodeOperatorInfo[node].validationTime -=
+            ($.vtPenaltyEpochs * vtPricePerEpoch * $.validators[moduleName][skippedIndex].numBatches);
+        --$.nodeOperatorInfo[node].pendingValidatorCount;
+
+        // Change the status of that validator
+        $.validators[moduleName][skippedIndex].status = Status.SKIPPED;
+
+        // Transfer pufETH to that node operator
+        // slither-disable-next-line unchecked-transfer
+        _PUFFER_VAULT.transfer(node, $.validators[moduleName][skippedIndex].bond);
+
+        _decreaseNumberOfRegisteredValidators($, moduleName);
+        unchecked {
+            ++$.nextToBeProvisioned[moduleName];
         }
-        require(
-            previousTotalEpochsValidated < epochsValidatedSignature.totalEpochsValidated, InvalidTotalEpochsValidated()
-        );
+        emit IPufferProtocol.ValidatorSkipped($.validators[moduleName][skippedIndex].pubKey, skippedIndex, moduleName);
+    }
 
-        // Burn the VT first, then fallback to ETH from the node operator
-        uint256 nodeVTBalance = $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance;
+    /**
+     * @notice Check IPufferProtocol.batchHandleWithdrawals
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _batchHandleWithdrawals(
+        StoppedValidatorInfo[] calldata validatorInfos,
+        bytes[] calldata guardianEOASignatures,
+        uint256 deadline
+    ) external payable override {
+        if (block.timestamp > deadline) {
+            revert DeadlineExceeded();
+        }
 
-        // If the node operator has VT, we burn it first
-        if (nodeVTBalance > 0) {
-            uint256 vtBurnAmount =
-                _getVTBurnAmount(epochsValidatedSignature.totalEpochsValidated - previousTotalEpochsValidated);
-            if (nodeVTBalance >= vtBurnAmount) {
-                // Burn the VT first, and update the node operator VT balance
-                vtAmountToBurn = vtBurnAmount;
-                // nosemgrep basic-arithmetic-underflow
-                $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance -= SafeCast.toUint96(vtBurnAmount);
+        _GUARDIAN_MODULE.validateBatchWithdrawals(validatorInfos, guardianEOASignatures, deadline);
 
-                emit IPufferProtocol.ValidationTimeConsumed({
-                    node: nodeOperator,
-                    consumedAmount: 0,
-                    deprecated_burntVTs: vtBurnAmount
-                });
+        ProtocolStorage storage $ = _getPufferProtocolStorage();
 
-                return vtAmountToBurn;
+        BurnAmounts memory burnAmounts;
+        Withdrawals[] memory bondWithdrawals = new Withdrawals[](validatorInfos.length);
+
+        // 1 batch = 32 ETH
+        uint256 numExitedBatches;
+
+        // slither-disable-start calls-loop
+        for (uint256 i = 0; i < validatorInfos.length; ++i) {
+            Validator storage validator =
+                $.validators[validatorInfos[i].moduleName][validatorInfos[i].pufferModuleIndex];
+
+            if (validator.status != Status.ACTIVE) {
+                revert InvalidValidatorState(validator.status);
             }
 
-            // If the node operator has less VT than the amount to burn, we burn all of it, and we use the validation time
-            vtAmountToBurn = nodeVTBalance;
-            // nosemgrep basic-arithmetic-underflow
-            $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance -= SafeCast.toUint96(nodeVTBalance);
+            // Save the Node address for the bond transfer
+            bondWithdrawals[i].node = validator.node;
+            uint256 bondBurnAmount;
+
+            // We need to scope the variables to avoid stack too deep errors
+            {
+                uint256 epochValidated = validatorInfos[i].totalEpochsValidated;
+                bytes[] memory vtConsumptionSignature = validatorInfos[i].vtConsumptionSignature;
+                burnAmounts.vt += _useVTOrValidationTime(
+                    $,
+                    EpochsValidatedSignature({
+                        nodeOperator: bondWithdrawals[i].node,
+                        totalEpochsValidated: epochValidated,
+                        functionSelector: _FUNCTION_SELECTOR_BATCH_HANDLE_WITHDRAWALS,
+                        deadline: deadline,
+                        signatures: vtConsumptionSignature
+                    })
+                );
+            }
+
+            if (validatorInfos[i].isDownsize) {
+                // We update the bondWithdrawals
+                (bondWithdrawals[i].pufETHAmount, bondWithdrawals[i].numBatches) =
+                    _downsizeValidators($, validatorInfos[i], validator);
+
+                numExitedBatches += bondWithdrawals[i].numBatches;
+            } else {
+                // Full validator exit
+                numExitedBatches += validator.numBatches;
+                bondWithdrawals[i].numBatches = validator.numBatches > 0 ? validator.numBatches : 1;
+
+                // We update the bondWithdrawals
+                (bondBurnAmount, bondWithdrawals[i].pufETHAmount, bondWithdrawals[i].numBatches) =
+                    _exitValidator($, validatorInfos[i], validator);
+            }
+
+            // Update the burnAmounts
+            burnAmounts.pufETH += bondBurnAmount;
         }
 
-        // If the node operator has no VT, we use the validation time
-        _settleVTAccounting({ epochsValidatedSignature: epochsValidatedSignature, deprecated_burntVTs: nodeVTBalance });
+        if (burnAmounts.vt > 0) {
+            _VALIDATOR_TICKET.burn(burnAmounts.vt);
+        }
+        if (burnAmounts.pufETH > 0) {
+            // Because we've calculated everything in the previous loop, we can do the burning
+            _PUFFER_VAULT.burn(burnAmounts.pufETH);
+        }
+
+        // Deduct 32 ETH per batch from the `lockedETHAmount` on the PufferOracle
+        _PUFFER_ORACLE.exitValidators(numExitedBatches);
+
+        _batchHandleWithdrawalsAccounting(bondWithdrawals, validatorInfos);
     }
 
     /**
@@ -151,11 +388,11 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
      * - signatures: The signatures of the guardians over the total number of epochs validated
      * @param deprecated_burntVTs The amount of VT to burn (to be deducted from validation time consumption)
      */
-    function _settleVTAccounting(EpochsValidatedSignature memory epochsValidatedSignature, uint256 deprecated_burntVTs)
-        public
-        payable
-    {
-        ProtocolStorage storage $ = _getPufferProtocolStorage();
+    function _settleVTAccounting(
+        ProtocolStorage storage $,
+        EpochsValidatedSignature memory epochsValidatedSignature,
+        uint256 deprecated_burntVTs
+    ) internal {
         address node = epochsValidatedSignature.nodeOperator;
         // There is nothing to settle if this is the first validator for the node operator
         if ($.nodeOperatorInfo[node].activeValidatorCount + $.nodeOperatorInfo[node].pendingValidatorCount == 0) {
@@ -204,6 +441,68 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
     }
 
     /**
+     * @dev Internal function to return the deprecated validator tickets burn amount
+     *      and/or consume the validation time from the node operator
+     * @dev The deprecated vt balance is reduced here but the actual VT is not burned here (for efficiency)
+     * @param epochsValidatedSignature is a struct that contains:
+     * - functionSelector: Identifier of the function that initiated this flow
+     * - totalEpochsValidated: The total number of epochs validated by that node operator
+     * - nodeOperator: The node operator address
+     * - deadline: The deadline for the signature
+     * - signatures: The signatures of the guardians over the total number of epochs validated
+     * @return vtAmountToBurn The amount of VT to burn
+     */
+    function _useVTOrValidationTime(ProtocolStorage storage $, EpochsValidatedSignature memory epochsValidatedSignature)
+        internal
+        returns (uint256 vtAmountToBurn)
+    {
+        address nodeOperator = epochsValidatedSignature.nodeOperator;
+        uint256 previousTotalEpochsValidated = $.nodeOperatorInfo[nodeOperator].totalEpochsValidated;
+
+        if (previousTotalEpochsValidated == epochsValidatedSignature.totalEpochsValidated) {
+            return 0;
+        }
+        require(
+            previousTotalEpochsValidated < epochsValidatedSignature.totalEpochsValidated, InvalidTotalEpochsValidated()
+        );
+
+        // Burn the VT first, then fallback to ETH from the node operator
+        uint256 nodeVTBalance = $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance;
+
+        // If the node operator has VT, we burn it first
+        if (nodeVTBalance > 0) {
+            uint256 vtBurnAmount =
+                _getVTBurnAmount(epochsValidatedSignature.totalEpochsValidated - previousTotalEpochsValidated);
+            if (nodeVTBalance >= vtBurnAmount) {
+                // Burn the VT first, and update the node operator VT balance
+                vtAmountToBurn = vtBurnAmount;
+                // nosemgrep basic-arithmetic-underflow
+                $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance -= SafeCast.toUint96(vtBurnAmount);
+
+                emit IPufferProtocol.ValidationTimeConsumed({
+                    node: nodeOperator,
+                    consumedAmount: 0,
+                    deprecated_burntVTs: vtBurnAmount
+                });
+
+                return vtAmountToBurn;
+            }
+
+            // If the node operator has less VT than the amount to burn, we burn all of it, and we use the validation time
+            vtAmountToBurn = nodeVTBalance;
+            // nosemgrep basic-arithmetic-underflow
+            $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance -= SafeCast.toUint96(nodeVTBalance);
+        }
+
+        // If the node operator has no VT, we use the validation time
+        _settleVTAccounting({
+            $: $,
+            epochsValidatedSignature: epochsValidatedSignature,
+            deprecated_burntVTs: nodeVTBalance
+        });
+    }
+
+    /**
      * @dev Internal function to get the amount of VT to burn during a number of epochs
      * @param validatedEpochs The number of epochs validated by the node operator (not necessarily the total epochs)
      * @return vtBurnAmount The amount of VT to burn
@@ -212,5 +511,160 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
         // Epoch has 32 blocks, each block is 12 seconds, we upscale to 18 decimals to get the VT amount and divide by 1 day
         // The formula is validatedEpochs * 32 * 12 * 1 ether / 1 days (4444444444444444.44444444...) we round it up
         return validatedEpochs * 4444444444444445;
+    }
+
+    function _batchHandleWithdrawalsAccounting(
+        Withdrawals[] memory bondWithdrawals,
+        StoppedValidatorInfo[] calldata validatorInfos
+    ) internal {
+        // In this loop, we transfer back the bonds, and do the accounting that affects the exchange rate
+        for (uint256 i = 0; i < validatorInfos.length; ++i) {
+            // If the withdrawal amount is bigger than 32 ETH * numBatches, we cap it to 32 ETH * numBatches
+            // The excess is the rewards amount for that Node Operator
+            uint256 transferAmount = validatorInfos[i].withdrawalAmount > (32 ether * bondWithdrawals[i].numBatches)
+                ? 32 ether * bondWithdrawals[i].numBatches
+                : validatorInfos[i].withdrawalAmount;
+            //solhint-disable-next-line avoid-low-level-calls
+            (bool success,) =
+                PufferModule(payable(validatorInfos[i].module)).call(address(_PUFFER_VAULT), transferAmount, "");
+            if (!success) {
+                revert Failed();
+            }
+
+            // Skip the empty transfer (validator got slashed)
+            if (bondWithdrawals[i].pufETHAmount == 0) {
+                continue;
+            }
+            // slither-disable-next-line unchecked-transfer
+            _PUFFER_VAULT.transfer(bondWithdrawals[i].node, bondWithdrawals[i].pufETHAmount);
+        }
+        // slither-disable-start calls-loop
+    }
+
+    function _downsizeValidators(
+        ProtocolStorage storage $,
+        StoppedValidatorInfo calldata validatorInfo,
+        Validator storage validator
+    ) internal returns (uint256 exitingBond, uint256 exitedBatches) {
+        exitedBatches = validatorInfo.withdrawalAmount / 32 ether;
+
+        uint256 numBatchesBefore = validator.numBatches;
+
+        // We burn the bond according to previous burn rate (before downsize)
+        uint256 burnAmount = _getBondBurnAmount({
+            validatorInfo: validatorInfo,
+            validatorBondAmount: validator.bond,
+            numBatches: numBatchesBefore
+        });
+
+        exitingBond = (validator.bond * exitedBatches) / validator.numBatches;
+
+        // The burned amount is subtracted from the exiting bond, so the remaining bond is kept in full
+        // The backend must prevent any downsize that would result in a burned amount greater than the exiting bond
+        require(exitingBond >= burnAmount, InvalidWithdrawAmount());
+        exitingBond -= burnAmount;
+
+        emit IPufferProtocol.ValidatorDownsized({
+            pubKey: validator.pubKey,
+            pufferModuleIndex: validatorInfo.pufferModuleIndex,
+            moduleName: validatorInfo.moduleName,
+            pufETHBurnAmount: burnAmount,
+            epoch: validatorInfo.totalEpochsValidated,
+            numBatchesBefore: numBatchesBefore,
+            numBatchesAfter: validator.numBatches - exitedBatches
+        });
+
+        $.nodeOperatorInfo[validator.node].numBatches -= SafeCast.toUint8(exitedBatches);
+
+        validator.bond -= SafeCast.toUint96(exitingBond);
+        validator.numBatches -= SafeCast.toUint8(exitedBatches);
+
+        return (exitingBond, exitedBatches);
+    }
+
+    function _exitValidator(
+        ProtocolStorage storage $,
+        StoppedValidatorInfo calldata validatorInfo,
+        Validator storage validator
+    ) internal returns (uint256 bondBurnAmount, uint256 bondReturnAmount, uint256 exitedBatches) {
+        uint96 bondAmount = validator.bond;
+        uint256 numBatches = validator.numBatches;
+
+        // Get the bondBurnAmount for the withdrawal at the current exchange rate
+        bondBurnAmount = _getBondBurnAmount({
+            validatorInfo: validatorInfo,
+            validatorBondAmount: bondAmount,
+            numBatches: validator.numBatches
+        });
+
+        emit IPufferProtocol.ValidatorExited({
+            pubKey: validator.pubKey,
+            pufferModuleIndex: validatorInfo.pufferModuleIndex,
+            moduleName: validatorInfo.moduleName,
+            pufETHBurnAmount: bondBurnAmount,
+            numBatches: numBatches
+        });
+
+        // Decrease the number of registered validators for that module
+        _decreaseNumberOfRegisteredValidators($, validatorInfo.moduleName);
+
+        // Storage VT and the active validator count update for the Node Operator
+        // nosemgrep basic-arithmetic-underflow
+        --$.nodeOperatorInfo[validator.node].activeValidatorCount;
+        $.nodeOperatorInfo[validator.node].numBatches -= validator.numBatches;
+
+        delete $.validators[validatorInfo.moduleName][
+            validatorInfo.pufferModuleIndex
+        ];
+        // nosemgrep basic-arithmetic-underflow
+        return (bondBurnAmount, bondAmount - bondBurnAmount, numBatches);
+    }
+
+    function _decreaseNumberOfRegisteredValidators(ProtocolStorage storage $, bytes32 moduleName) internal {
+        --$.moduleLimits[moduleName].numberOfRegisteredValidators;
+        emit IPufferProtocol.NumberOfRegisteredValidatorsChanged(
+            moduleName, $.moduleLimits[moduleName].numberOfRegisteredValidators
+        );
+    }
+
+    function _getBondBurnAmount(
+        StoppedValidatorInfo calldata validatorInfo,
+        uint256 validatorBondAmount,
+        uint256 numBatches
+    ) internal view returns (uint256 pufETHBurnAmount) {
+        // Case 1:
+        // The Validator was slashed, we burn the whole bond for that validator
+        if (validatorInfo.wasSlashed) {
+            return validatorBondAmount;
+        }
+
+        // Case 2:
+        // The withdrawal amount is less than 32 ETH * numBatches, we burn the difference to cover up the loss for inactivity
+        if (validatorInfo.withdrawalAmount < (uint256(32 ether) * numBatches)) {
+            pufETHBurnAmount =
+                _PUFFER_VAULT.convertToSharesUp((uint256(32 ether) * numBatches) - validatorInfo.withdrawalAmount);
+        }
+
+        // Case 3:
+        // Withdrawal amount was >= 32 ETH * numBatches, we don't burn anything
+        return pufETHBurnAmount;
+    }
+
+    function _checkValidatorRegistrationInputs(
+        ProtocolStorage storage $,
+        ValidatorKeyData calldata data,
+        bytes32 moduleName
+    ) internal view {
+        // Check number of batches between 1 (32 ETH) and 64 (2048 ETH)
+        require(0 < data.numBatches && data.numBatches < 65, InvalidNumberOfBatches());
+
+        // This acts as a validation if the module is existent
+        // +1 is to validate the current transaction registration
+        require(
+            ($.moduleLimits[moduleName].numberOfRegisteredValidators + 1) <= $.moduleLimits[moduleName].allowedLimit,
+            ValidatorLimitForModuleReached()
+        );
+
+        require(data.blsPubKey.length == _BLS_PUB_KEY_LENGTH, InvalidBLSPubKey());
     }
 }

--- a/mainnet-contracts/src/PufferProtocolLogic.sol
+++ b/mainnet-contracts/src/PufferProtocolLogic.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { PufferProtocolStorage } from "./PufferProtocolStorage.sol";
 import { ProtocolStorage } from "./struct/ProtocolStorage.sol";
 import { ProtocolSignatureNonces } from "./ProtocolSignatureNonces.sol";
@@ -8,8 +10,37 @@ import { Validator } from "./struct/Validator.sol";
 import { Status } from "./struct/Validator.sol";
 import { ProtocolConstants } from "./ProtocolConstants.sol";
 import { IPufferProtocol } from "./interface/IPufferProtocol.sol";
+import { PufferModuleManager } from "./PufferModuleManager.sol";
+import { IPufferOracleV2 } from "./interface/IPufferOracleV2.sol";
+import { IGuardianModule } from "./interface/IGuardianModule.sol";
+import { IBeaconDepositContract } from "./interface/IBeaconDepositContract.sol";
+import { ValidatorTicket } from "./ValidatorTicket.sol";
+import { PufferVaultV5 } from "./PufferVaultV5.sol";
+import { EpochsValidatedSignature } from "./struct/Signatures.sol";
+
+import "forge-std/console.sol";
 
 contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, ProtocolConstants {
+    constructor(
+        PufferVaultV5 pufferVault,
+        IGuardianModule guardianModule,
+        address moduleManager,
+        ValidatorTicket validatorTicket,
+        IPufferOracleV2 oracle,
+        address beaconDepositContract,
+        address payable pufferRevenueDistributor
+    )
+        ProtocolConstants(
+            pufferVault,
+            guardianModule,
+            moduleManager,
+            validatorTicket,
+            oracle,
+            beaconDepositContract,
+            pufferRevenueDistributor
+        )
+    { }
+
     /**
      * @dev This function should only be called by the PufferProtocol contract through a delegatecall
      */
@@ -50,5 +81,138 @@ contract PufferProtocolLogic is PufferProtocolStorage, ProtocolSignatureNonces, 
         $.modules[moduleName].requestConsolidation{ value: msg.value }(srcPubkeys, targetPubkeys);
 
         emit IPufferProtocol.ConsolidationRequested(moduleName, srcPubkeys, targetPubkeys);
+    }
+
+    /**
+     * @dev Internal function to return the deprecated validator tickets burn amount
+     *      and/or consume the validation time from the node operator
+     * @dev The deprecated vt balance is reduced here but the actual VT is not burned here (for efficiency)
+     * @param epochsValidatedSignature is a struct that contains:
+     * - functionSelector: Identifier of the function that initiated this flow
+     * - totalEpochsValidated: The total number of epochs validated by that node operator
+     * - nodeOperator: The node operator address
+     * - deadline: The deadline for the signature
+     * - signatures: The signatures of the guardians over the total number of epochs validated
+     * @return vtAmountToBurn The amount of VT to burn
+     */
+    function _useVTOrValidationTime(EpochsValidatedSignature memory epochsValidatedSignature)
+        external
+        returns (uint256 vtAmountToBurn)
+    {
+        ProtocolStorage storage $ = _getPufferProtocolStorage();
+        address nodeOperator = epochsValidatedSignature.nodeOperator;
+        uint256 previousTotalEpochsValidated = $.nodeOperatorInfo[nodeOperator].totalEpochsValidated;
+
+        if (previousTotalEpochsValidated == epochsValidatedSignature.totalEpochsValidated) {
+            return 0;
+        }
+        require(
+            previousTotalEpochsValidated < epochsValidatedSignature.totalEpochsValidated, InvalidTotalEpochsValidated()
+        );
+
+        // Burn the VT first, then fallback to ETH from the node operator
+        uint256 nodeVTBalance = $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance;
+
+        // If the node operator has VT, we burn it first
+        if (nodeVTBalance > 0) {
+            uint256 vtBurnAmount =
+                _getVTBurnAmount(epochsValidatedSignature.totalEpochsValidated - previousTotalEpochsValidated);
+            if (nodeVTBalance >= vtBurnAmount) {
+                // Burn the VT first, and update the node operator VT balance
+                vtAmountToBurn = vtBurnAmount;
+                // nosemgrep basic-arithmetic-underflow
+                $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance -= SafeCast.toUint96(vtBurnAmount);
+
+                emit IPufferProtocol.ValidationTimeConsumed({
+                    node: nodeOperator,
+                    consumedAmount: 0,
+                    deprecated_burntVTs: vtBurnAmount
+                });
+
+                return vtAmountToBurn;
+            }
+
+            // If the node operator has less VT than the amount to burn, we burn all of it, and we use the validation time
+            vtAmountToBurn = nodeVTBalance;
+            // nosemgrep basic-arithmetic-underflow
+            $.nodeOperatorInfo[nodeOperator].deprecated_vtBalance -= SafeCast.toUint96(nodeVTBalance);
+        }
+
+        // If the node operator has no VT, we use the validation time
+        _settleVTAccounting({ epochsValidatedSignature: epochsValidatedSignature, deprecated_burntVTs: nodeVTBalance });
+    }
+
+    /**
+     * @dev Internal function to settle the VT accounting for a node operator
+     * @param epochsValidatedSignature is a struct that contains:
+     * - functionSelector: Identifier of the function that initiated this flow
+     * - totalEpochsValidated: The total number of epochs validated by that node operator
+     * - nodeOperator: The node operator address
+     * - deadline: The deadline for the signature
+     * - signatures: The signatures of the guardians over the total number of epochs validated
+     * @param deprecated_burntVTs The amount of VT to burn (to be deducted from validation time consumption)
+     */
+    function _settleVTAccounting(EpochsValidatedSignature memory epochsValidatedSignature, uint256 deprecated_burntVTs)
+        public
+    {
+        console.log("settleVTAccounting");
+
+        ProtocolStorage storage $ = _getPufferProtocolStorage();
+        address node = epochsValidatedSignature.nodeOperator;
+        // There is nothing to settle if this is the first validator for the node operator
+        if ($.nodeOperatorInfo[node].activeValidatorCount + $.nodeOperatorInfo[node].pendingValidatorCount == 0) {
+            return;
+        }
+
+        _GUARDIAN_MODULE.validateTotalEpochsValidated({
+            node: node,
+            totalEpochsValidated: epochsValidatedSignature.totalEpochsValidated,
+            nonce: _useNonce(epochsValidatedSignature.functionSelector, node),
+            deadline: epochsValidatedSignature.deadline,
+            guardianEOASignatures: epochsValidatedSignature.signatures
+        });
+
+        uint256 epochCurrentPrice = _PUFFER_ORACLE.getValidatorTicketPrice();
+
+        uint256 meanPrice = ($.nodeOperatorInfo[node].epochPrice + epochCurrentPrice) / 2;
+
+        uint256 previousTotalEpochsValidated = $.nodeOperatorInfo[node].totalEpochsValidated;
+
+        // convert burned validator tickets to epochs
+        uint256 epochsBurntFromDeprecatedVT = (deprecated_burntVTs * 225) / 1 ether; // 1 VT = 1 DAY. 1 DAY = 225 Epochs
+
+        uint256 validationTimeToConsume = (
+            epochsValidatedSignature.totalEpochsValidated - previousTotalEpochsValidated - epochsBurntFromDeprecatedVT
+        ) * meanPrice;
+
+        // Update the current epoch VT price for the node operator
+        $.nodeOperatorInfo[node].epochPrice = epochCurrentPrice;
+        $.nodeOperatorInfo[node].totalEpochsValidated = epochsValidatedSignature.totalEpochsValidated;
+        $.nodeOperatorInfo[node].validationTime -= validationTimeToConsume;
+
+        emit IPufferProtocol.ValidationTimeConsumed({
+            node: node,
+            consumedAmount: validationTimeToConsume,
+            deprecated_burntVTs: deprecated_burntVTs
+        });
+
+        address weth = _PUFFER_VAULT.asset();
+
+        // WETH is a contract that has a fallback function that accepts ETH, and never reverts
+        weth.call{ value: validationTimeToConsume }("");
+
+        // Transfer WETH to the Revenue Distributor, it will be slow released to the PufferVault
+        ERC20(weth).transfer(_PUFFER_REVENUE_DISTRIBUTOR, validationTimeToConsume);
+    }
+
+    /**
+     * @dev Internal function to get the amount of VT to burn during a number of epochs
+     * @param validatedEpochs The number of epochs validated by the node operator (not necessarily the total epochs)
+     * @return vtBurnAmount The amount of VT to burn
+     */
+    function _getVTBurnAmount(uint256 validatedEpochs) internal pure returns (uint256) {
+        // Epoch has 32 blocks, each block is 12 seconds, we upscale to 18 decimals to get the VT amount and divide by 1 day
+        // The formula is validatedEpochs * 32 * 12 * 1 ether / 1 days (4444444444444444.44444444...) we round it up
+        return validatedEpochs * 4444444444444445;
     }
 }

--- a/mainnet-contracts/src/PufferProtocolLogic.sol
+++ b/mainnet-contracts/src/PufferProtocolLogic.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { PufferProtocolStorage } from "./PufferProtocolStorage.sol";
+import { ProtocolStorage } from "./struct/ProtocolStorage.sol";
+import { ProtocolSignatureNonces } from "./ProtocolSignatureNonces.sol";
+import { Validator } from "./struct/Validator.sol";
+import { Status } from "./struct/Validator.sol";
+import { ProtocolConstants } from "./ProtocolConstants.sol";
+import { IPufferProtocol } from "./interface/IPufferProtocol.sol";
+
+contract PufferProtocolLogic is
+    PufferProtocolStorage,
+    ProtocolSignatureNonces,
+    ProtocolConstants
+{
+
+    /**
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _requestConsolidation(bytes32 moduleName, uint256[] calldata srcIndices, uint256[] calldata targetIndices)
+        external
+        payable
+    {
+        if (srcIndices.length == 0) {
+            revert InputArrayLengthZero();
+        }
+        if (srcIndices.length != targetIndices.length) {
+            revert InputArrayLengthMismatch();
+        }
+
+        ProtocolStorage storage $ = _getPufferProtocolStorage();
+
+        bytes[] memory srcPubkeys = new bytes[](srcIndices.length);
+        bytes[] memory targetPubkeys = new bytes[](targetIndices.length);
+        Validator storage validatorSrc;
+        Validator storage validatorTarget;
+        for (uint256 i = 0; i < srcPubkeys.length; i++) {
+            require(srcIndices[i] != targetIndices[i], InvalidValidator());
+            validatorSrc = $.validators[moduleName][srcIndices[i]];
+            require(validatorSrc.node == msg.sender && validatorSrc.status == Status.ACTIVE, InvalidValidator());
+            srcPubkeys[i] = validatorSrc.pubKey;
+            validatorTarget = $.validators[moduleName][targetIndices[i]];
+            require(validatorTarget.node == msg.sender && validatorTarget.status == Status.ACTIVE, InvalidValidator());
+            targetPubkeys[i] = validatorTarget.pubKey;
+
+            // Update accounting
+            validatorTarget.bond += validatorSrc.bond;
+            validatorTarget.numBatches += validatorSrc.numBatches;
+
+            delete $.validators[moduleName][srcIndices[i]];
+            // Node info needs no update since all stays in the same node operator
+        }
+
+        $.modules[moduleName].requestConsolidation{ value: msg.value }(srcPubkeys, targetPubkeys);
+
+        emit IPufferProtocol.ConsolidationRequested(moduleName, srcPubkeys, targetPubkeys);
+    }
+}

--- a/mainnet-contracts/src/interface/IGuardianModule.sol
+++ b/mainnet-contracts/src/interface/IGuardianModule.sol
@@ -167,17 +167,37 @@ interface IGuardianModule {
 
     /**
      * @notice Validates the withdrawal request
-     * @param eoaSignatures The guardian EOA signatures
-     * @param messageHash The message hash
+     * @param node The node operator address
+     * @param pubKey The public key
+     * @param gweiAmount The amount in gwei
+     * @param nonce The nonce for the node and the function selector
+     * @param deadline The deadline of the signature
+     * @param guardianEOASignatures The guardian EOA signatures
      */
-    function validateWithdrawalRequest(bytes[] calldata eoaSignatures, bytes32 messageHash) external view;
+    function validateWithdrawalRequest(
+        address node,
+        bytes memory pubKey,
+        uint256 gweiAmount,
+        uint256 nonce,
+        uint256 deadline,
+        bytes[] calldata guardianEOASignatures
+    ) external view;
 
     /**
      * @notice Validates the total epochs validated
-     * @param eoaSignatures The guardian EOA signatures
-     * @param messageHash The message hash
+     * @param node The node operator address
+     * @param totalEpochsValidated The total epochs validated
+     * @param nonce The nonce for the node and the function selector
+     * @param deadline The deadline of the signature
+     * @param guardianEOASignatures The guardian EOA signatures
      */
-    function validateTotalEpochsValidated(bytes[] calldata eoaSignatures, bytes32 messageHash) external view;
+    function validateTotalEpochsValidated(
+        address node,
+        uint256 totalEpochsValidated,
+        uint256 nonce,
+        uint256 deadline,
+        bytes[] calldata guardianEOASignatures
+    ) external view;
 
     /**
      * @notice Returns the threshold value for guardian signatures

--- a/mainnet-contracts/src/interface/IPufferProtocol.sol
+++ b/mainnet-contracts/src/interface/IPufferProtocol.sol
@@ -23,8 +23,6 @@ import { IBeaconDepositContract } from "../interface/IBeaconDepositContract.sol"
  * @custom:security-contact security@puffer.fi
  */
 interface IPufferProtocol {
-
-
     /**
      * @notice Emitted when the number of active validators changes
      * @dev Signature "0xc06afc2b3c88873a9be580de9bbbcc7fea3027ef0c25fd75d5411ed3195abcec"

--- a/mainnet-contracts/src/interface/IPufferProtocol.sol
+++ b/mainnet-contracts/src/interface/IPufferProtocol.sol
@@ -23,100 +23,7 @@ import { IBeaconDepositContract } from "../interface/IBeaconDepositContract.sol"
  * @custom:security-contact security@puffer.fi
  */
 interface IPufferProtocol {
-    /**
-     * @notice Thrown when the deposit state that is provided doesn't match the one on Beacon deposit contract
-     */
-    error InvalidDepositRootHash();
 
-    /**
-     * @notice Thrown when the node operator tries to withdraw VTs from the PufferProtocol but has active/pending validators
-     * @dev Signature "0x22242546"
-     */
-    error ActiveOrPendingValidatorsExist();
-
-    /**
-     * @notice Thrown on the module creation if the module already exists
-     * @dev Signature "0x2157f2d7"
-     */
-    error ModuleAlreadyExists();
-
-    /**
-     * @notice Thrown when the new validators tires to register to a module, but the validator limit for that module is already reached
-     * @dev Signature "0xb75c5781"
-     */
-    error ValidatorLimitForModuleReached();
-
-    /**
-     * @notice Thrown when the BLS public key is not valid
-     * @dev Signature "0x7eef7967"
-     */
-    error InvalidBLSPubKey();
-
-    /**
-     * @notice Thrown when validator is not in a valid state
-     * @dev Signature "0x3001591c"
-     */
-    error InvalidValidatorState(Status status);
-
-    /**
-     * @notice Thrown if the sender did not send enough ETH in the transaction
-     * @dev Signature "0x242b035c"
-     */
-    error InvalidETHAmount();
-
-    /**
-     * @notice Thrown if the sender tries to register validator with invalid VT amount
-     * @dev Signature "0x95c01f62"
-     */
-    error InvalidVTAmount();
-
-    /**
-     * @notice Thrown if the ETH transfer from the PufferModule to the PufferVault fails
-     * @dev Signature "0x625a40e6"
-     */
-    error Failed();
-
-    /**
-     * @notice Thrown if the validator is not valid
-     * @dev Signature "0x682a6e7c"
-     */
-    error InvalidValidator();
-
-    /**
-     * @notice Thrown if the input array length mismatch
-     * @dev Signature "0x43714afd"
-     */
-    error InputArrayLengthMismatch();
-
-    /**
-     * @notice Thrown if the input array length is zero
-     * @dev Signature "0x796cc525"
-     */
-    error InputArrayLengthZero();
-
-    /**
-     * @notice Thrown if the number of batches is 0 or greater than 64
-     * @dev Signature "0x4ea54df9"
-     */
-    error InvalidNumberOfBatches();
-
-    /**
-     * @notice Thrown if the withdrawal amount is invalid
-     * @dev Signature "0xdb73cdf0"
-     */
-    error InvalidWithdrawAmount();
-
-    /**
-     * @notice Thrown when the total epochs validated is invalid
-     * @dev Signature "0x1af51909"
-     */
-    error InvalidTotalEpochsValidated();
-
-    /**
-     * @notice Thrown when the deadline is exceeded
-     * @dev Signature "0xddff8620"
-     */
-    error DeadlineExceeded();
 
     /**
      * @notice Emitted when the number of active validators changes
@@ -263,6 +170,12 @@ interface IPufferProtocol {
     event SuccessfullyProvisioned(
         bytes pubKey, uint256 indexed pufferModuleIndex, bytes32 indexed moduleName, uint256 numBatches
     );
+
+    /**
+     * @notice Emitted when the PufferProtocolLogic is set
+     * @dev Signature "0xe271f36954242c619ce9d0f727a7d3b5f4db04666752aaeb20bca6d52098792a"
+     */
+    event PufferProtocolLogicSet(address oldPufferProtocolLogic, address newPufferProtocolLogic);
 
     /**
      * @notice Returns validator information

--- a/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
+++ b/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
@@ -2,40 +2,55 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { EpochsValidatedSignature } from "../struct/Signatures.sol";
+import { StoppedValidatorInfo } from "../struct/StoppedValidatorInfo.sol";
+import { ValidatorKeyData } from "../struct/ValidatorKeyData.sol";
 
 interface IPufferProtocolLogic {
+    /**
+     * @notice Check IPufferProtocol.depositValidationTime
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _depositValidationTime(EpochsValidatedSignature memory epochsValidatedSignature) external payable;
+
+    /**
+     * @notice Check IPufferProtocol.withdrawValidationTime
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _withdrawValidationTime(uint96 amount, address recipient) external;
+
+    /**
+     * @notice Check IPufferProtocol.registerValidatorKey
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
+    function _registerValidatorKey(
+        ValidatorKeyData calldata data,
+        bytes32 moduleName,
+        uint256 totalEpochsValidated,
+        bytes[] calldata vtConsumptionSignature,
+        uint256 deadline
+    ) external payable;
+
+    /**
+     * @notice Check IPufferProtocol.requestConsolidation
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
+     */
     function _requestConsolidation(bytes32 moduleName, uint256[] calldata srcIndices, uint256[] calldata targetIndices)
         external
         payable;
 
     /**
-     * @dev Internal function to return the deprecated validator tickets burn amount
-     *      and/or consume the validation time from the node operator
-     * @dev The deprecated vt balance is reduced here but the actual VT is not burned here (for efficiency)
-     * @param epochsValidatedSignature is a struct that contains:
-     * - functionSelector: Identifier of the function that initiated this flow
-     * - totalEpochsValidated: The total number of epochs validated by that node operator
-     * - nodeOperator: The node operator address
-     * - deadline: The deadline for the signature
-     * - signatures: The signatures of the guardians over the total number of epochs validated
-     * @return vtAmountToBurn The amount of VT to burn
+     * @notice Check IPufferProtocol.skipProvisioning
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
      */
-    function _useVTOrValidationTime(EpochsValidatedSignature memory epochsValidatedSignature)
-        external
-        payable
-        returns (uint256 vtAmountToBurn);
+    function _skipProvisioning(bytes32 moduleName, bytes[] calldata guardianEOASignatures) external;
 
     /**
-     * @dev Internal function to settle the VT accounting for a node operator
-     * @param epochsValidatedSignature is a struct that contains:
-     * - functionSelector: Identifier of the function that initiated this flow
-     * - totalEpochsValidated: The total number of epochs validated by that node operator
-     * - nodeOperator: The node operator address
-     * - deadline: The deadline for the signature
-     * - signatures: The signatures of the guardians over the total number of epochs validated
-     * @param deprecated_burntVTs The amount of VT to burn (to be deducted from validation time consumption)
+     * @notice Check IPufferProtocol.batchHandleWithdrawals
+     * @dev This function should only be called by the PufferProtocol contract through a delegatecall
      */
-    function _settleVTAccounting(EpochsValidatedSignature memory epochsValidatedSignature, uint256 deprecated_burntVTs)
-        external
-        payable;
+    function _batchHandleWithdrawals(
+        StoppedValidatorInfo[] calldata validatorInfos,
+        bytes[] calldata guardianEOASignatures,
+        uint256 deadline
+    ) external payable;
 }

--- a/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
+++ b/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
@@ -22,6 +22,7 @@ interface IPufferProtocolLogic {
      */
     function _useVTOrValidationTime(EpochsValidatedSignature memory epochsValidatedSignature)
         external
+        payable
         returns (uint256 vtAmountToBurn);
 
     /**
@@ -35,5 +36,6 @@ interface IPufferProtocolLogic {
      * @param deprecated_burntVTs The amount of VT to burn (to be deducted from validation time consumption)
      */
     function _settleVTAccounting(EpochsValidatedSignature memory epochsValidatedSignature, uint256 deprecated_burntVTs)
-        external;
+        external
+        payable;
 }

--- a/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
+++ b/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+
+interface IPufferProtocolLogic {
+    function _requestConsolidation(bytes32 moduleName, uint256[] calldata srcIndices, uint256[] calldata targetIndices) external payable;
+}

--- a/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
+++ b/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
@@ -1,8 +1,39 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import { EpochsValidatedSignature } from "../struct/Signatures.sol";
+
 interface IPufferProtocolLogic {
     function _requestConsolidation(bytes32 moduleName, uint256[] calldata srcIndices, uint256[] calldata targetIndices)
         external
         payable;
+
+    /**
+     * @dev Internal function to return the deprecated validator tickets burn amount
+     *      and/or consume the validation time from the node operator
+     * @dev The deprecated vt balance is reduced here but the actual VT is not burned here (for efficiency)
+     * @param epochsValidatedSignature is a struct that contains:
+     * - functionSelector: Identifier of the function that initiated this flow
+     * - totalEpochsValidated: The total number of epochs validated by that node operator
+     * - nodeOperator: The node operator address
+     * - deadline: The deadline for the signature
+     * - signatures: The signatures of the guardians over the total number of epochs validated
+     * @return vtAmountToBurn The amount of VT to burn
+     */
+    function _useVTOrValidationTime(EpochsValidatedSignature memory epochsValidatedSignature)
+        external
+        returns (uint256 vtAmountToBurn);
+
+    /**
+     * @dev Internal function to settle the VT accounting for a node operator
+     * @param epochsValidatedSignature is a struct that contains:
+     * - functionSelector: Identifier of the function that initiated this flow
+     * - totalEpochsValidated: The total number of epochs validated by that node operator
+     * - nodeOperator: The node operator address
+     * - deadline: The deadline for the signature
+     * - signatures: The signatures of the guardians over the total number of epochs validated
+     * @param deprecated_burntVTs The amount of VT to burn (to be deducted from validation time consumption)
+     */
+    function _settleVTAccounting(EpochsValidatedSignature memory epochsValidatedSignature, uint256 deprecated_burntVTs)
+        external;
 }

--- a/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
+++ b/mainnet-contracts/src/interface/IPufferProtocolLogic.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-
 interface IPufferProtocolLogic {
-    function _requestConsolidation(bytes32 moduleName, uint256[] calldata srcIndices, uint256[] calldata targetIndices) external payable;
+    function _requestConsolidation(bytes32 moduleName, uint256[] calldata srcIndices, uint256[] calldata targetIndices)
+        external
+        payable;
 }

--- a/mainnet-contracts/src/struct/ProtocolStorage.sol
+++ b/mainnet-contracts/src/struct/ProtocolStorage.sol
@@ -66,7 +66,6 @@ struct ProtocolStorage {
      * Slot 9
      */
     uint256 vtPenaltyEpochs;
-
     /**
      * @dev Address of the PufferProtocolLogic contract
      * Slot 10

--- a/mainnet-contracts/src/struct/ProtocolStorage.sol
+++ b/mainnet-contracts/src/struct/ProtocolStorage.sol
@@ -66,6 +66,12 @@ struct ProtocolStorage {
      * Slot 9
      */
     uint256 vtPenaltyEpochs;
+
+    /**
+     * @dev Address of the PufferProtocolLogic contract
+     * Slot 10
+     */
+    address pufferProtocolLogic;
 }
 
 struct ModuleLimit {

--- a/mainnet-contracts/test/unit/PufferProtocol.t.sol
+++ b/mainnet-contracts/test/unit/PufferProtocol.t.sol
@@ -26,6 +26,8 @@ import { StoppedValidatorInfo } from "../../src/struct/StoppedValidatorInfo.sol"
 import { NodeInfo } from "../../src/struct/NodeInfo.sol";
 import { EpochsValidatedSignature } from "../../src/struct/Signatures.sol";
 
+import "forge-std/console.sol";
+
 contract PufferProtocolTest is UnitTestHelper {
     using ECDSA for bytes32;
 
@@ -1049,6 +1051,7 @@ contract PufferProtocolTest is UnitTestHelper {
 
     // Batch claim 32 ETH withdrawals
     function test_batch_claim() public {
+        console.log(pufferProtocol.getPufferProtocolLogic());
         _registerAndProvisionNode(bytes32("alice"), PUFFER_MODULE_0, alice);
         _registerAndProvisionNode(bytes32("bob"), PUFFER_MODULE_0, bob);
 

--- a/mainnet-contracts/test/unit/PufferProtocol.t.sol
+++ b/mainnet-contracts/test/unit/PufferProtocol.t.sol
@@ -9,6 +9,7 @@ import { ValidatorKeyData } from "../../src/struct/ValidatorKeyData.sol";
 import { Status } from "../../src/struct/Status.sol";
 import { Validator } from "../../src/struct/Validator.sol";
 import { PufferProtocol } from "../../src/PufferProtocol.sol";
+import { ProtocolConstants } from "../../src/ProtocolConstants.sol";
 import { PufferModule } from "../../src/PufferModule.sol";
 import { PufferRevenueDepositor } from "../../src/PufferRevenueDepositor.sol";
 import {
@@ -186,7 +187,7 @@ contract PufferProtocolTest is UnitTestHelper {
     // Create an existing module should revert
     function test_create_existing_module_fails() public {
         vm.startPrank(DAO);
-        vm.expectRevert(IPufferProtocol.ModuleAlreadyExists.selector);
+        vm.expectRevert(ProtocolConstants.ModuleAlreadyExists.selector);
         pufferProtocol.createPufferModule(PUFFER_MODULE_0);
     }
 
@@ -195,7 +196,7 @@ contract PufferProtocolTest is UnitTestHelper {
         uint256 smoothingCommitment = pufferOracle.getValidatorTicketPrice() * 30;
         bytes memory pubKey = _getPubKey(bytes32("charlie"));
         ValidatorKeyData memory validatorKeyData = _getMockValidatorKeyData(pubKey, PUFFER_MODULE_0);
-        vm.expectRevert(IPufferProtocol.ValidatorLimitForModuleReached.selector);
+        vm.expectRevert(ProtocolConstants.ValidatorLimitForModuleReached.selector);
         pufferProtocol.registerValidatorKey{ value: smoothingCommitment }(
             validatorKeyData, bytes32("imaginary module"), 0, new bytes[](0), block.timestamp + 1 days
         );
@@ -246,14 +247,14 @@ contract PufferProtocolTest is UnitTestHelper {
             numBatches: 0
         });
 
-        vm.expectRevert(IPufferProtocol.InvalidNumberOfBatches.selector);
+        vm.expectRevert(ProtocolConstants.InvalidNumberOfBatches.selector);
         pufferProtocol.registerValidatorKey{ value: vtPrice }(
             validatorData, PUFFER_MODULE_0, 0, new bytes[](0), block.timestamp + 1 days
         );
 
         validatorData.numBatches = 65;
 
-        vm.expectRevert(IPufferProtocol.InvalidNumberOfBatches.selector);
+        vm.expectRevert(ProtocolConstants.InvalidNumberOfBatches.selector);
         pufferProtocol.registerValidatorKey{ value: vtPrice }(
             validatorData, PUFFER_MODULE_0, 0, new bytes[](0), block.timestamp + 1 days
         );
@@ -277,7 +278,7 @@ contract PufferProtocolTest is UnitTestHelper {
             numBatches: 1
         });
 
-        vm.expectRevert(IPufferProtocol.InvalidBLSPubKey.selector);
+        vm.expectRevert(ProtocolConstants.InvalidBLSPubKey.selector);
         pufferProtocol.registerValidatorKey{ value: smoothingCommitment }(
             validatorData, PUFFER_MODULE_0, 0, new bytes[](0), block.timestamp + 1 days
         );
@@ -298,7 +299,7 @@ contract PufferProtocolTest is UnitTestHelper {
 
         bytes memory validatorSignature = _validatorSignature();
 
-        vm.expectRevert(IPufferProtocol.InvalidDepositRootHash.selector);
+        vm.expectRevert(ProtocolConstants.InvalidDepositRootHash.selector);
         pufferProtocol.provisionNode(validatorSignature, bytes32("badDepositRoot")); // "depositRoot" is hardcoded in the mock
 
         // now it works
@@ -598,7 +599,7 @@ contract PufferProtocolTest is UnitTestHelper {
         bytes memory pubKey = _getPubKey(bytes32("bob"));
         ValidatorKeyData memory validatorKeyData = _getMockValidatorKeyData(pubKey, PUFFER_MODULE_0);
 
-        vm.expectRevert(IPufferProtocol.ValidatorLimitForModuleReached.selector);
+        vm.expectRevert(ProtocolConstants.ValidatorLimitForModuleReached.selector);
         pufferProtocol.registerValidatorKey{ value: (smoothingCommitment + BOND) }(
             validatorKeyData, PUFFER_MODULE_0, 0, new bytes[](0), block.timestamp + 1 days
         );
@@ -812,7 +813,7 @@ contract PufferProtocolTest is UnitTestHelper {
         // Register Validator key registers validator with 30 VTs
         _registerValidatorKey(alice, bytes32("alice"), PUFFER_MODULE_0, 0);
 
-        vm.expectRevert(IPufferProtocol.ActiveOrPendingValidatorsExist.selector);
+        vm.expectRevert(ProtocolConstants.ActiveOrPendingValidatorsExist.selector);
         pufferProtocol.withdrawValidatorTickets(30 ether, alice);
     }
 
@@ -861,13 +862,13 @@ contract PufferProtocolTest is UnitTestHelper {
 
     function test_setVTPenalty_bigger_than_minimum_VT_amount() public {
         vm.startPrank(DAO);
-        vm.expectRevert(IPufferProtocol.InvalidVTAmount.selector);
+        vm.expectRevert(ProtocolConstants.InvalidVTAmount.selector);
         pufferProtocol.setVTPenalty(50 * EPOCHS_PER_DAY);
     }
 
     function test_changeMinimumVTAmount_lower_than_penalty() public {
         vm.startPrank(DAO);
-        vm.expectRevert(IPufferProtocol.InvalidVTAmount.selector);
+        vm.expectRevert(ProtocolConstants.InvalidVTAmount.selector);
         pufferProtocol.changeMinimumVTAmount(9 * EPOCHS_PER_DAY);
     }
 
@@ -987,7 +988,7 @@ contract PufferProtocolTest is UnitTestHelper {
         bytes[] memory vtConsumptionSignature = _getGuardianSignaturesForRegistration(alice, 28 * EPOCHS_PER_DAY);
 
         // We've removed the validator data, meaning the validator status is 0 (UNINITIALIZED)
-        vm.expectRevert(abi.encodeWithSelector(IPufferProtocol.InvalidValidatorState.selector, 0));
+        vm.expectRevert(abi.encodeWithSelector(ProtocolConstants.InvalidValidatorState.selector, 0));
         _executeFullWithdrawal(
             StoppedValidatorInfo({
                 module: NoRestakingModule,
@@ -2034,7 +2035,7 @@ contract PufferProtocolTest is UnitTestHelper {
 
     function test_setVTPenalty_invalid_amount() public {
         vm.startPrank(DAO);
-        vm.expectRevert(IPufferProtocol.InvalidVTAmount.selector);
+        vm.expectRevert(ProtocolConstants.InvalidVTAmount.selector);
         pufferProtocol.setVTPenalty(type(uint256).max);
     }
 
@@ -2042,7 +2043,7 @@ contract PufferProtocolTest is UnitTestHelper {
         bytes memory invalidPubKey = new bytes(47); // Invalid length
         ValidatorKeyData memory data = _getMockValidatorKeyData(invalidPubKey, PUFFER_MODULE_0);
 
-        vm.expectRevert(IPufferProtocol.InvalidBLSPubKey.selector);
+        vm.expectRevert(ProtocolConstants.InvalidBLSPubKey.selector);
         pufferProtocol.registerValidatorKey{ value: 3 ether }(
             data, PUFFER_MODULE_0, 0, new bytes[](0), block.timestamp + 1 days
         );
@@ -2050,7 +2051,7 @@ contract PufferProtocolTest is UnitTestHelper {
 
     function test_changeMinimumVTAmount_invalid_amount() public {
         vm.startPrank(DAO);
-        vm.expectRevert(IPufferProtocol.InvalidVTAmount.selector);
+        vm.expectRevert(ProtocolConstants.InvalidVTAmount.selector);
         pufferProtocol.changeMinimumVTAmount(0);
     }
 

--- a/mainnet-contracts/test/unit/PufferProtocol.t.sol
+++ b/mainnet-contracts/test/unit/PufferProtocol.t.sol
@@ -26,7 +26,6 @@ import { StoppedValidatorInfo } from "../../src/struct/StoppedValidatorInfo.sol"
 import { NodeInfo } from "../../src/struct/NodeInfo.sol";
 import { EpochsValidatedSignature } from "../../src/struct/Signatures.sol";
 
-import "forge-std/console.sol";
 
 contract PufferProtocolTest is UnitTestHelper {
     using ECDSA for bytes32;
@@ -1051,7 +1050,6 @@ contract PufferProtocolTest is UnitTestHelper {
 
     // Batch claim 32 ETH withdrawals
     function test_batch_claim() public {
-        console.log(pufferProtocol.getPufferProtocolLogic());
         _registerAndProvisionNode(bytes32("alice"), PUFFER_MODULE_0, alice);
         _registerAndProvisionNode(bytes32("bob"), PUFFER_MODULE_0, bob);
 


### PR DESCRIPTION
Before this PR, due to the changes for Pectra and the Validator Tokens => Validation Time rework, the size of the PufferProtocol contract had reached 28.5 KB, way over the limit.

In this PR I've implemented a contract that offloads a big part of the logic of the PufferProtocol contract. The way to call this contract is via delegatecall so the storage is the PufferProtocol's. A new base contract has been created so both PufferProtocol and PufferProtocolLogic share constants, immutables, storage, errors, and other common stuff.

The contract size achieved is 18.2 KB, so there's more than enough space to continue with the Pectra implementation and add some more features. 

The PR includes some changes to the tests but they're not related to the PufferProtocolLogic contract. They were adapted so the previous tests could work with the changes made regarding the signatures. The changes to the protocol and protocol logic contract have not altered the tests and they still pass