### PR TITLE
Fixed issue 2 of 1sw fee audit

### DIFF
--- a/mainnet-contracts/src/PufferVaultV5.sol
+++ b/mainnet-contracts/src/PufferVaultV5.sol
@@ -507,9 +507,12 @@ contract PufferVaultV5 is
     function maxWithdraw(address owner) public view virtual override returns (uint256 maxAssets) {
         uint256 maxUserAssets = previewRedeem(balanceOf(owner));
 
-        uint256 vaultLiquidity = (_WETH.balanceOf(address(this)) + (address(this).balance));
+        uint256 availableLiquidity = (_WETH.balanceOf(address(this)) + (address(this).balance));
+
+        availableLiquidity -= _feeOnRaw(availableLiquidity, getTotalExitFeeBasisPoints());
+
         // Return the minimum of user's assets and available liquidity
-        return Math.min(maxUserAssets, vaultLiquidity);
+        return Math.min(maxUserAssets, availableLiquidity);
     }
 
     /**
@@ -524,7 +527,7 @@ contract PufferVaultV5 is
         // Calculate max shares based on available liquidity (WETH + ETH balance)
         uint256 availableLiquidity = _WETH.balanceOf(address(this)) + (address(this).balance);
         // Calculate how many shares can be redeemed from the available liquidity after fees
-        uint256 maxSharesFromLiquidity = previewWithdraw(availableLiquidity);
+        uint256 maxSharesFromLiquidity = super.previewWithdraw(availableLiquidity);
         // Return the minimum of user's shares and shares from available liquidity
         return Math.min(shares, maxSharesFromLiquidity);
     }

--- a/mainnet-contracts/test/mocks/PufferVaultV5Liq.sol
+++ b/mainnet-contracts/test/mocks/PufferVaultV5Liq.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { PufferVaultV5 } from "src/PufferVaultV5.sol";
+import { IStETH } from "src/interface/Lido/IStETH.sol";
+import { ILidoWithdrawalQueue } from "src/interface/Lido/ILidoWithdrawalQueue.sol";
+import { IWETH } from "src/interface/Other/IWETH.sol";
+import { IPufferOracleV2 } from "src/interface/IPufferOracleV2.sol";
+import { IPufferRevenueDepositor } from "src/interface/IPufferRevenueDepositor.sol";
+
+contract PufferVaultV5Liq is PufferVaultV5 {
+    uint256 private _lockedLiquidity;
+
+    constructor(
+        IStETH stETH,
+        IWETH weth,
+        ILidoWithdrawalQueue lidoWithdrawalQueue,
+        IPufferOracleV2 oracle,
+        IPufferRevenueDepositor revenueDepositor
+    ) PufferVaultV5(stETH, lidoWithdrawalQueue, weth, oracle, revenueDepositor) {
+        _disableInitializers();
+    }
+
+    // This functionality must be disabled because of the foundry tests
+    modifier markDeposit() virtual override {
+        _;
+    }
+
+    function reduceLiquidity(uint256 amount) external {
+        _lockedLiquidity = amount;
+        payable(msg.sender).transfer(amount);
+    }
+
+    function totalAssets() public view override returns (uint256) {
+        return super.totalAssets() + _lockedLiquidity;
+    }
+}


### PR DESCRIPTION
There was an incorrect calculation in the maxRedeem and maxWithdraw function with availableLiquidity was limited due to the fees.

New calculation correctly removes fees from available liquidity in these functions