### PR TITLE
L2-Rewards - Increased claiming delay windows

### DIFF
--- a/l2-contracts/src/L2RewardManager.sol
+++ b/l2-contracts/src/L2RewardManager.sol
@@ -353,7 +353,7 @@ contract L2RewardManager is
         if (newDelay < 6 hours) {
             revert InvalidDelayPeriod();
         }
-        if (newDelay > 12 hours) {
+        if (newDelay > 72 hours) {
             revert InvalidDelayPeriod();
         }
         RewardManagerStorage storage $ = _getRewardManagerStorage();

--- a/l2-contracts/test/unit/L2RewardManager.t.sol
+++ b/l2-contracts/test/unit/L2RewardManager.t.sol
@@ -324,9 +324,9 @@ contract L2RewardManagerTest is Test, TestHelperOz5 {
         l2RewardManager.setDelayPeriod(1 hours);
 
         vm.expectRevert(abi.encodeWithSelector(IL2RewardManager.InvalidDelayPeriod.selector));
-        l2RewardManager.setDelayPeriod(15 hours);
+        l2RewardManager.setDelayPeriod(73 hours);
 
-        uint256 delayPeriod = 10 hours;
+        uint256 delayPeriod = 48 hours;
         l2RewardManager.setDelayPeriod(delayPeriod);
         assertEq(l2RewardManager.getClaimingDelay(), delayPeriod, "Claiming delay should be set correctly");
     }


### PR DESCRIPTION
Increased the top boundary of claiming delay to 72 hours in L2RewardsManager